### PR TITLE
Enforce template-first SKILL.md generation in skill-writing skill

### DIFF
--- a/skills/software-engineering/skill-writing/README.md
+++ b/skills/software-engineering/skill-writing/README.md
@@ -6,7 +6,7 @@ It is useful when a user has an idea like "create a skill for code review" or "m
 
 ## What it creates
 
-- `SKILL.md` — the main behavior specification
+- `SKILL.md` — the main behavior specification (always generated from `repo-config/skill-template.md`)
 - `README.md` — user-facing documentation
 - `examples.md` — realistic examples of how the skill should behave
 - `test-cases.yaml` — checkable scenarios for evaluating the skill

--- a/skills/software-engineering/skill-writing/SKILL.md
+++ b/skills/software-engineering/skill-writing/SKILL.md
@@ -81,6 +81,8 @@ Focus on practical usefulness: scope, instructions, examples, edge cases, safety
 
 ### Skill Writing Process
 
+
+0. Before drafting `SKILL.md`, load and use `repo-config/skill-template.md` as the required base template.
 1. Identify the skill's core purpose from the user's prompt.
 2. Derive a concise skill name, stable skill ID, version, status, owner, and last-updated date.
 3. Define the intended user value and the concrete tasks the skill supports.
@@ -98,7 +100,9 @@ Focus on practical usefulness: scope, instructions, examples, edge cases, safety
 
 ### File Generation Guidelines
 
-When generating a complete skill package, use this default structure unless the user asks otherwise:
+When generating a complete skill package, use this default structure unless the user asks otherwise.
+
+`SKILL.md` must always be created by filling `repo-config/skill-template.md` (do not create ad-hoc SKILL.md structures):
 
 ```text
 <skill-name>/
@@ -110,19 +114,9 @@ When generating a complete skill package, use this default structure unless the 
 
 #### `SKILL.md`
 
-Include:
+Use the sections and ordering from `repo-config/skill-template.md` exactly, then fill each section with skill-specific content.
 
-- Title
-- Metadata
-- Purpose
-- Use Cases
-- Not For
-- Inputs
-- Output
-- Instructions
-- Default Output Format
-
-The `SKILL.md` file is the authoritative behavioral specification.
+The `SKILL.md` file is the authoritative behavioral specification and must remain template-aligned.
 
 #### `README.md`
 

--- a/skills/software-engineering/skill-writing/test-cases.yaml
+++ b/skills/software-engineering/skill-writing/test-cases.yaml
@@ -83,3 +83,13 @@ test_cases:
       - scopes the skill to generating ADR documents from user-provided context
       - includes assumptions and open questions for missing technical context
       - includes tests for missing decision drivers and unsupported claims
+
+
+  - name: always_uses_repo_skill_template
+    input: |
+      Create a skill called "customer-support-triage".
+      Generate all files.
+    expected_behavior:
+      - reads and applies repo-config/skill-template.md before drafting SKILL.md
+      - keeps SKILL.md section order aligned with the template
+      - does not output an ad-hoc SKILL.md structure


### PR DESCRIPTION
### Motivation
- Ensure `skill-writing` always uses the central `repo-config/skill-template.md` when producing `SKILL.md` to maintain consistent structure and avoid ad-hoc layouts.
- Make the generation guidance explicit so produced skills follow repository conventions and are easier to review and test.
- Add a test that detects regressions if a `SKILL.md` is produced without applying the shared template.

### Description
- Updated `skills/software-engineering/skill-writing/SKILL.md` to require loading `repo-config/skill-template.md` before drafting any `SKILL.md` and to mandate template-aligned section ordering.
- Updated `skills/software-engineering/skill-writing/README.md` to note that `SKILL.md` is always generated from the repository template.
- Added the `always_uses_repo_skill_template` test case to `skills/software-engineering/skill-writing/test-cases.yaml` which asserts template application and prohibits ad-hoc `SKILL.md` structures.

### Testing
- Ran repository checks including `git diff` and `git status` and committed the changes, all of which completed successfully.
- Created the PR metadata via the `make_pr` helper, which completed successfully.
- No automated unit/CI tests for runtime skill behavior were executed because this change updates documentation and test definitions only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f71738f4b08328b21c9b9a0f7b6478)