### PR TITLE
Embed all investment-research skills in Senior Financial Analyst GPT

### DIFF
--- a/gpts/senior-financial-analyst/config.md
+++ b/gpts/senior-financial-analyst/config.md
@@ -35,7 +35,7 @@ Path:
 Files:
 
 - `README.md`
-- `SKILL.md`
+- `skill.md`
 - `examples.md`
 - `test-cases.yaml`
 
@@ -48,7 +48,46 @@ Path:
 Files:
 
 - `README.md`
-- `SKILL.md`
+- `skill.md`
+- `test-cases.yaml`
+
+### Discounted Cash Flow Calculation
+
+Path:
+
+`skills/investment-research/discounted-cash-flow-calculation/`
+
+Files:
+
+- `README.md`
+- `skill.md`
+- `examples.md`
+- `test-cases.yaml`
+
+### Business Capital Preservation Score
+
+Path:
+
+`skills/investment-research/business-capital-preservation-score/`
+
+Files:
+
+- `README.md`
+- `skill.md`
+- `examples.md`
+- `test-cases.yaml`
+
+### Shareholder Capital Preservation Score
+
+Path:
+
+`skills/investment-research/shareholder-capital-preservation-score/`
+
+Files:
+
+- `README.md`
+- `skill.md`
+- `examples.md`
 - `test-cases.yaml`
 
 ## Recommended GPT Capabilities

--- a/gpts/senior-financial-analyst/instructions.md
+++ b/gpts/senior-financial-analyst/instructions.md
@@ -13,11 +13,20 @@ When users ask for filing analysis, fundamentals extraction, trend analysis, ris
 1. Start with:
    - `gpts/senior-financial-analyst/repo-map.md`
 2. Apply:
-   - `skills/investment-research/company-analysis/SKILL.md`
+   - `skills/investment-research/company-analysis/skill.md`
    - `skills/investment-research/company-analysis/examples.md`
    - `skills/investment-research/company-analysis/test-cases.yaml`
-   - `skills/investment-research/reports-search/SKILL.md`
+   - `skills/investment-research/reports-search/skill.md`
    - `skills/investment-research/reports-search/test-cases.yaml`
+   - `skills/investment-research/discounted-cash-flow-calculation/skill.md`
+   - `skills/investment-research/discounted-cash-flow-calculation/examples.md`
+   - `skills/investment-research/discounted-cash-flow-calculation/test-cases.yaml`
+   - `skills/investment-research/business-capital-preservation-score/skill.md`
+   - `skills/investment-research/business-capital-preservation-score/examples.md`
+   - `skills/investment-research/business-capital-preservation-score/test-cases.yaml`
+   - `skills/investment-research/shareholder-capital-preservation-score/skill.md`
+   - `skills/investment-research/shareholder-capital-preservation-score/examples.md`
+   - `skills/investment-research/shareholder-capital-preservation-score/test-cases.yaml`
    - `repo-config/quality-checklist.md`
 3. Prefer repository skill behavior over generic behavior.
 4. If repository content is unavailable, state that explicitly and continue with best-effort behavior.

--- a/gpts/senior-financial-analyst/repo-map.md
+++ b/gpts/senior-financial-analyst/repo-map.md
@@ -16,7 +16,7 @@ This repository is the source of truth for the Senior Financial Analyst GPT.
 ### 1) Company Analysis Skill
 
 - `skills/investment-research/company-analysis/README.md`
-- `skills/investment-research/company-analysis/SKILL.md`
+- `skills/investment-research/company-analysis/skill.md`
 - `skills/investment-research/company-analysis/examples.md`
 - `skills/investment-research/company-analysis/test-cases.yaml`
 
@@ -30,7 +30,7 @@ Use for:
 ### 2) Reports Search Skill
 
 - `skills/investment-research/reports-search/README.md`
-- `skills/investment-research/reports-search/SKILL.md`
+- `skills/investment-research/reports-search/skill.md`
 - `skills/investment-research/reports-search/test-cases.yaml`
 
 Use for:
@@ -38,6 +38,42 @@ Use for:
 - Discovering relevant analyst/research reports
 - Filtering by sector, region, report type, and date range
 - Returning ranked, summarized results
+
+### 3) Discounted Cash Flow Calculation Skill
+
+- `skills/investment-research/discounted-cash-flow-calculation/README.md`
+- `skills/investment-research/discounted-cash-flow-calculation/skill.md`
+- `skills/investment-research/discounted-cash-flow-calculation/examples.md`
+- `skills/investment-research/discounted-cash-flow-calculation/test-cases.yaml`
+
+Use for:
+
+- Building explicit DCF assumptions and valuation outputs
+- Sensitivity framing and assumption transparency
+
+### 4) Business Capital Preservation Score Skill
+
+- `skills/investment-research/business-capital-preservation-score/README.md`
+- `skills/investment-research/business-capital-preservation-score/skill.md`
+- `skills/investment-research/business-capital-preservation-score/examples.md`
+- `skills/investment-research/business-capital-preservation-score/test-cases.yaml`
+
+Use for:
+
+- Evaluating business durability and downside resilience
+- Producing structured preservation scoring rationale
+
+### 5) Shareholder Capital Preservation Score Skill
+
+- `skills/investment-research/shareholder-capital-preservation-score/README.md`
+- `skills/investment-research/shareholder-capital-preservation-score/skill.md`
+- `skills/investment-research/shareholder-capital-preservation-score/examples.md`
+- `skills/investment-research/shareholder-capital-preservation-score/test-cases.yaml`
+
+Use for:
+
+- Evaluating shareholder-level dilution, payout quality, and capital protection
+- Producing structured preservation scoring rationale
 
 ## Shared Quality References
 


### PR DESCRIPTION
### Motivation
- Ensure the Senior Financial Analyst GPT references and applies the full set of investment-research skills present in the repository rather than only a subset. 
- Fix mismatched skill filename references so documentation points to actual files and avoids broken links.

### Description
- Added `discounted-cash-flow-calculation`, `business-capital-preservation-score`, and `shareholder-capital-preservation-score` to the active skills inventory in `gpts/senior-financial-analyst/config.md`. 
- Replaced incorrect `SKILL.md` references with the correct `skill.md` filenames across `gpts/senior-financial-analyst/config.md`, `gpts/senior-financial-analyst/instructions.md`, and `gpts/senior-financial-analyst/repo-map.md`. 
- Expanded the Source-of-Truth workflow in `gpts/senior-financial-analyst/instructions.md` to apply examples and test cases for each investment-research skill. 
- Extended `gpts/senior-financial-analyst/repo-map.md` with new sections and concise "Use for" guidance for the added skills.

### Testing
- Verified repository file discovery with `rg --files` and confirmed all `skills/investment-research` directories exist, which succeeded. 
- Confirmed references to `skill.md` and `investment-research` appear in package docs using `rg -n 'skill\.md|investment-research' gpts/senior-financial-analyst/*.md`, which succeeded. 
- Listed and inspected updated files with `nl -ba gpts/senior-financial-analyst/*.md` to validate content changes, which succeeded. 
- Ran `git status --short` to confirm the working tree included the updated package docs, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f727b985688328aa5d344f5a0a7952)